### PR TITLE
Fix incorrect pointer declaration in picosatmodule

### DIFF
--- a/tt/_clibs/picosatmodule.c
+++ b/tt/_clibs/picosatmodule.c
@@ -22,7 +22,7 @@ typedef struct {
     PyObject_HEAD
     PicoSAT * picosat;
     PyObject * assumptions;
-    signed char _temp_mem;
+    signed char * _temp_mem;
 } soliter_obj;
 
 


### PR DESCRIPTION
This issue is blocking since GCC14.
I have only read the code and reproduce the issue with the compiler but I haven't done extra tests.

close #11 